### PR TITLE
Switch : Add possibility to press title + add description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ buck-out/
 */fastlane/report.xml
 */fastlane/Preview.html
 */fastlane/screenshots
+
+#vs code
+.vscode/

--- a/README.md
+++ b/README.md
@@ -206,7 +206,11 @@ Prop | Description | Type | Default
 `disabledOverlayStyle` | component overlay style if setting is disabled | ViewPropTypes | `{}`
 `titleProps` | title props except style | `Text` Component Props | `{}`
 `titleStyle` | title style prop | `Text` PropTypes | `{}`
-`title` | title of setting | String | *Required*
+`title` | title of setting | String | *Required* | String | *Required*
+`onTitlePress` | callback to be invoked when the title is pressed. If defined, a vertical divider is added before the switch | Function | null
+`descriptionProps` | description props except style | `Text` Component Props | `{}`
+`descriptionStyle` | description style prop | `Text` PropTypes | `{}`
+`description` | description of setting | String | null
 `switchWrapperProps` | switch wrapper props except style | `View` Component Props | `{}`
 `switchWrapperStyle` | switch wrapper style prop | `View` PropTypes | `{}`
 `value` | value of setting | Boolean | *Required*

--- a/README.md
+++ b/README.md
@@ -161,12 +161,14 @@ Prop | Description | Type | Default
 `valueStyle` | value style prop | `Text` PropTypes | `{}`
 `value` | value of setting | String | *Required*
 `valuePlaceholder` | placeholder if value is empty | String | `...`
+`valueDisplay` | Value formatter | Function (String) => String | null
 `negativeButtonTitle` | negative dialog buttons title | String | *Required*
 `positiveButtonTitle` | positive dialog buttons title | String | *Required*
 `dialogDescription` | text explaining what the user should do e.g. | String | `''``
 `onSaveValue` | callback to be invoked when the positive dialog button is pressed | String | *Required*
 `disabled` | whether the settings value should be editable or not | Boolean | `false`
 `iosDialogInputType` | input type of the dialog alert on ios | String | `plain-text`
+`androidDialogInputType` | input type of the dialog alert on android (see [`Android InputType`](https://developer.android.com/reference/android/text/InputType.html)) | Number | 1
 `androidDialogProps` | input dialog props on android (see [`react-native-dialogs`](https://github.com/aakashns/react-native-dialogs)) | String | `{}`
 `touchableProps` | props of touchable opening input dialog | String | `{}`
 

--- a/src/edit-text/edit-text.js
+++ b/src/edit-text/edit-text.js
@@ -15,6 +15,7 @@ class SettingsEditText extends Component {
         valueProps: PropTypes.object,
         valueStyle: Text.propTypes.style,
         value: PropTypes.string.isRequired,
+        valueFormat: PropTypes.func,
         valuePlaceholder: PropTypes.string,
         negativeButtonTitle: PropTypes.string.isRequired,
         positiveButtonTitle: PropTypes.string.isRequired,
@@ -22,6 +23,7 @@ class SettingsEditText extends Component {
         onSaveValue: PropTypes.func.isRequired,
         disabled: PropTypes.bool,
         iosDialogInputType: PropTypes.string,
+        androidDialogInputType: PropTypes.number,
         androidDialogProps: PropTypes.object,
         touchableProps: PropTypes.object,
     };
@@ -35,9 +37,11 @@ class SettingsEditText extends Component {
         valueProps: {},
         valuePlaceholder: '...',
         valueStyle: {},
+        valueFormat: null,
         dialogDescription: '',
         disabled: false,
         iosDialogInputType: 'plain-text',
+        androidDialogInputType: 1,
         androidDialogProps: {},
         touchableProps: {},
     };
@@ -50,7 +54,7 @@ class SettingsEditText extends Component {
 
         const {disabled, dialogDescription, negativeButtonTitle, positiveButtonTitle, onSaveValue, androidDialogProps,
             containerProps, containerStyle, title, titleProps, titleStyle, valueProps, valueStyle, valuePlaceholder,
-            disabledOverlayStyle, touchableProps, iosDialogInputType, value} = this.props;
+            disabledOverlayStyle, touchableProps, iosDialogInputType, androidDialogInputType, value, valueFormat} = this.props;
 
         return (!disabled) ? <TouchableOpacity {...touchableProps} onPress={() => {
             if(Platform.OS === 'ios') {
@@ -80,6 +84,7 @@ class SettingsEditText extends Component {
                             value = this.trimValue(value);
                             onSaveValue(value);
                         },
+                        type: androidDialogInputType,
                     },
                     ...androidDialogProps
                 });
@@ -89,11 +94,11 @@ class SettingsEditText extends Component {
         }>
             <View {...containerProps} style={[styles.defaultContainerStyle, containerStyle]}>
                 <Text numberOfLines={1} {...titleProps} style={[styles.defaultTitleStyle, titleStyle]}>{title}</Text>
-                <Text numberOfLines={1} {...valueProps} style={[styles.defaultValueStyle, valueStyle]}>{(value) ? value : valuePlaceholder}</Text>
+                <Text numberOfLines={1} {...valueProps} style={[styles.defaultValueStyle, valueStyle]}>{(value) ? (valueFormat ? valueFormat(value): value) : valuePlaceholder}</Text>
             </View>
         </TouchableOpacity> : <View {...containerProps} style={[styles.defaultContainerStyle, containerStyle]}>
             <Text numberOfLines={1} {...titleProps} style={[styles.defaultTitleStyle, titleStyle]}>{title}</Text>
-            <Text numberOfLines={1} {...valueProps} style={[styles.defaultValueStyle, valueStyle]}>{(value) ? value : valuePlaceholder}</Text>
+            <Text numberOfLines={1} {...valueProps} style={[styles.defaultValueStyle, valueStyle]}>{(value) ? (valueFormat ? valueFormat(value): value) : valuePlaceholder}</Text>
             <View style={[{position: "absolute", top: 0, right: 0, bottom: 0, left: 0}, styles.defaultDisabledOverlayStyle, disabledOverlayStyle]}/>
         </View>
     }

--- a/src/switch/switch.js
+++ b/src/switch/switch.js
@@ -19,7 +19,11 @@ class SettingsSwitch extends Component {
         disabledOverlayStyle: PropTypes.object,
         titleProps: PropTypes.object,
         titleStyle: Text.propTypes.style,
-        title: PropTypes.string,
+        title: PropTypes.string.isRequired,
+        onTitlePress: PropTypes.func,
+        descriptionProps: PropTypes.object,
+        descriptionStyle: Text.propTypes.style,
+        description: PropTypes.string,
         switchWrapperProps: PropTypes.object,
         switchWrapperStyle: ViewPropTypes ? ViewPropTypes.style : View.propTypes.style,
         value: PropTypes.bool.isRequired,
@@ -36,6 +40,10 @@ class SettingsSwitch extends Component {
         disabledOverlayStyle: {},
         titleProps: {},
         titleStyle: {},
+        onTitlePress: null,
+        descriptionProps: {},
+        descriptionStyle: {},
+        description: null,
         switchWrapperProps: {},
         switchWrapperStyle: {},
         disabled: false,
@@ -44,16 +52,32 @@ class SettingsSwitch extends Component {
 
     render() {
 
-        const {container, containerStyle, titleProps, titleStyle, title, disabled, switchProps, disabledOverlayStyle,
-            switchWrapperProps, switchWrapperStyle, value, thumbTintColor, onTintColor, onSaveValue} = this.props;
+        const {container, containerStyle, titleProps, titleStyle, title, descriptionProps, descriptionStyle, description, disabled, switchProps, disabledOverlayStyle,
+            switchWrapperProps, switchWrapperStyle, value, thumbTintColor, onTintColor, onSaveValue, onTitlePress} = this.props;
 
         return <View {...container} style={[styles.defaultContainerStyle, containerStyle]}>
-            <View style={{flex: 1, position: 'relative'}}>
-                <Text {...titleProps}
-                      style={[styles.defaultTitleStyle, titleStyle]}>{title}</Text>
-                {(disabled) ? <View style={[{position: "absolute", top: 0, right: 0, bottom: 0, left: 0},
-                    styles.defaultDisabledOverlayStyle, (disabled) ? disabledOverlayStyle : null]}/> : null}
-            </View>
+            { onTitlePress ?
+                [
+                    <TouchableOpacity disabled={disabled} style={{flex: 1, position: 'relative', marginVertical: 10}} onPress={onTitlePress}>
+                        <Text {...titleProps}
+                            style={[styles.defaultTitleStyle, titleStyle]}>{title}</Text>
+                        {description != null && <Text {...descriptionProps}
+                            style={[styles.defaultDescriptionStyle, descriptionStyle]}>{description}</Text>}
+                        {(disabled) ? <View style={[{position: "absolute", top: 0, right: 0, bottom: 0, left: 0},
+                            styles.defaultDisabledOverlayStyle, (disabled) ? disabledOverlayStyle : null]}/> : null}
+                    </TouchableOpacity>,
+                    <View style={{width: 1, height: "60%", marginLeft: 20, backgroundColor: "rgb(220,220,223)"}}>
+                    </View>
+                ] :
+                <View style={{flex: 1, position: 'relative', marginVertical: 10}}>
+                    <Text {...titleProps}
+                        style={[styles.defaultTitleStyle, titleStyle]}>{title}</Text>
+                    {description != null && <Text {...descriptionProps}
+                        style={[styles.defaultDescriptionStyle, descriptionStyle]}>{description}</Text>}
+                    {(disabled) ? <View style={[{position: "absolute", top: 0, right: 0, bottom: 0, left: 0},
+                        styles.defaultDisabledOverlayStyle, (disabled) ? disabledOverlayStyle : null]}/> : null}
+                </View>
+            }
             <View {...switchWrapperProps}
                   style={[styles.defaultSwitchWrapperStyle, switchWrapperStyle]}>
                 <Switch
@@ -72,7 +96,7 @@ class SettingsSwitch extends Component {
 const styles = StyleSheet.create({
     defaultContainerStyle: {
         padding: 0,
-        height: 50,
+        minHeight: 50,
         backgroundColor: "white",
         alignItems: "center",
         flexDirection: "row",
@@ -83,12 +107,19 @@ const styles = StyleSheet.create({
         paddingRight: 8,
         fontSize: 16,
     },
+    defaultDescriptionStyle: {
+        flex: 0,
+        paddingLeft: 16,
+        paddingRight: 8,
+        fontSize: 12,
+    },
     defaultSwitchWrapperStyle: {
         flex: 0,
         flexDirection: "row",
         paddingLeft: 8,
         paddingRight: 16,
-    }, defaultDisabledOverlayStyle: {
+    }, 
+    defaultDisabledOverlayStyle: {
         backgroundColor: "rgba(255,255,255,0.6)",
     }
 


### PR DESCRIPTION
I enhance the switch settings by adding the possibility to configure an action by pressing the title and adding a description.
It looks like this :
![image](https://user-images.githubusercontent.com/1957019/36157058-2d632198-10d9-11e8-8d9a-c52a17beeda3.png)
