### PR TITLE
Fix DialogAndroid.set is undefined

### DIFF
--- a/src/edit-text/edit-text.js
+++ b/src/edit-text/edit-text.js
@@ -69,7 +69,7 @@ class SettingsEditText extends Component {
                 );
             } else {
                 let dialog = new DialogAndroid();
-                dialog.set({
+                dialog.prompt({
                     title: title,
                     content: dialogDescription,
                     positiveText: positiveButtonTitle,

--- a/src/edit-text/edit-text.js
+++ b/src/edit-text/edit-text.js
@@ -46,6 +46,22 @@ class SettingsEditText extends Component {
         return (val) ? val.trim() : '';
     };
 
+    async renderAndroidDialog(title, dialogDescription, positiveButtonTitle, negativeButtonTitle, onSaveValue){
+
+      const { action, text } = await DialogAndroid.prompt(title, dialogDescription, {
+        defaultValue: (this.value) ? this.value : "",
+        positiveText: positiveButtonTitle,
+        negativeText: negativeButtonTitle
+      });
+
+      if (action === DialogAndroid.actionPositive) {
+          var value = text;
+          value = this.trimValue(value);
+          this.value = value;
+          onSaveValue(value);
+      }
+    }
+
     render() {
 
         const {disabled, dialogDescription, negativeButtonTitle, positiveButtonTitle, onSaveValue, androidDialogProps,
@@ -68,22 +84,7 @@ class SettingsEditText extends Component {
                     (value) ? value : ""
                 );
             } else {
-                let dialog = new DialogAndroid();
-                dialog.prompt({
-                    title: title,
-                    content: dialogDescription,
-                    positiveText: positiveButtonTitle,
-                    negativeText: negativeButtonTitle,
-                    input: {
-                        prefill: (value) ? value : '',
-                        callback: (value) => {
-                            value = this.trimValue(value);
-                            onSaveValue(value);
-                        },
-                    },
-                    ...androidDialogProps
-                });
-                dialog.show();
+              this.renderAndroidDialog(title, dialogDescription, positiveButtonTitle, negativeButtonTitle, onSaveValue);
             }
         }
         }>


### PR DESCRIPTION
https://github.com/aakashns/react-native-dialogs has been updated and DialogAndroid has no longer the function ```set```. It has been replaced by the ```prompt```method.