### PR TITLE
AlertIOS is deprecated - use Alert instead

### DIFF
--- a/src/edit-text/edit-text.jsx
+++ b/src/edit-text/edit-text.jsx
@@ -5,7 +5,7 @@ import {
   TouchableOpacity,
   View,
   Platform,
-  AlertIOS,
+  Alert,
 } from 'react-native';
 import PropTypes from 'prop-types';
 import DialogAndroid from 'react-native-dialogs';
@@ -169,7 +169,7 @@ class SettingsEditText extends Component {
       iosDialogInputType, value,
     } = this.props;
     if (Platform.OS === 'ios') {
-      AlertIOS.prompt(
+      Alert.prompt(
         title,
         dialogDescription,
         [


### PR DESCRIPTION
Dialogs would not render on my device, with this change it performs as
expected

I am unsure if this also works on Android as I couldn't test it! Felt it safer to leave Android as-is