### PR TITLE
Typescript type declarations

### DIFF
--- a/src/button/button.jsx
+++ b/src/button/button.jsx
@@ -57,7 +57,6 @@ class SettingsButton extends Component {
     rightIcon: PropTypes.func,
     disabled: PropTypes.bool,
     onPress: PropTypes.func.isRequired,
-
   };
 
   static defaultProps = {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8,3 +8,10 @@ interface SettingsDividerShortProps {
 	dividerStyle?:ViewStyle,
 }
 type SettingsDividerShort = React.Component<SettingsDividerShortProps>;
+
+interface SettingsDividerLongProps {
+	ios?:boolean,
+	android?:boolean,
+	dividerStyle?:ViewStyle,
+}
+type SettingsDividerLong = React.Component<SettingsDividerLongProps>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { GestureResponderEvent, TextProps, TextStyle, TouchableOpacityProps, View, ViewProps, ViewStyle } from 'react-native'
+import { 
+	GestureResponderEvent, 
+	TextProps, 
+	TextStyle, 
+	TouchableOpacityProps, 
+	ViewProps, 
+	ViewStyle
+} from 'react-native'
 
 interface SettingsDividerShortProps {
 	ios?:boolean,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -114,3 +114,12 @@ interface SettingCategoryHeaderProps {
 	title: string
 }
 type SettingsCategoryHeader = React.Component<SettingCategoryHeaderProps>;
+
+interface SettingsTextLabelProps {
+	container?: ViewProps,
+	containerStyle?: ViewStyle,
+	titleProps?: TextProps,
+	titleStyle?: TextStyle,
+	title: string,  
+}
+type SettingsTextLabel = React.Component<SettingsTextLabelProps>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { TextProps, TextStyle, TouchableOpacityProps, ViewProps, ViewStyle } from 'react-native'
+import { TextProps, TextStyle, TouchableOpacityProps, View, ViewProps, ViewStyle } from 'react-native'
 
 interface SettingsDividerShortProps {
 	ios?:boolean,
@@ -65,3 +65,44 @@ interface SettingsEditTextProps {
 	touchableProps?: TouchableOpacityProps
 }
 type SettingsEditText = React.Component<SettingsEditTextProps>;
+
+interface SettingsPickerProps {
+	containerProps?: ViewProps,
+    containerStyle?: ViewStyle,
+    disabledOverlayStyle?: ViewStyle,
+    titleProps?: TextProps,
+    titleStyle?: TextStyle,
+    title: string,
+    valueProps?: TextProps,
+    valueStyle?: TextStyle,
+    value?: any,
+    valueFormat?: (input:T<any>)=>T,
+    valuePlaceholder?: string,
+    options: Array<any>, //I honestly don't know how to type this
+    dialogDescription?: string,
+    onValueChange: (value:any)=>void,
+    disabled?: boolean,
+    modalStyle?: {
+      innerWrapper: ViewStyle,
+      header: {
+        titleWrapper: ViewStyle,
+        title: TextStyle,
+        description: TextStyle,
+        closeBtnWrapper: ViewStyle,
+      },
+      list: {
+        wrapper: ViewStyle,
+        scrollView: ViewStyle,
+        innerWrapper: ViewStyle,
+      },
+    },
+    multi?: boolean,
+	renderCloseBtn?: JSX.Element,
+	// ↓↓↓ I'm not gonna read through the code that deeply to type every prop,
+	// ↓↓↓ especially since I won't use SettingsPicker at all in my app.
+	// ↓↓↓ If you want, type it correctly urself
+	renderListItem?: JSX.Element<{any:any}>, 
+    singleRadio?: boolean,
+}
+type SettingsPicker = React.Component<SettingsPickerProps>;
+

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { 
 	GestureResponderEvent, 
+	SwitchProps,
 	TextProps, 
 	TextStyle, 
 	TouchableOpacityProps, 
@@ -150,7 +151,7 @@ export interface SettingsSwitchProps {
       true: string,
       false: string,
     },
-    switchProps: object,
+    switchProps?: SwitchProps,
 }
 export declare class SettingsSwitch extends React.Component<SettingsSwitchProps> {}
 
@@ -170,4 +171,4 @@ export interface SettingsButtonProps {
     disabled?: boolean,
     onPress: (event: GestureResponderEvent) => void,
 }
-export declare class SettingSwitch extends React.Component<SettingsButtonProps> {}
+export declare class SettingsButton extends React.Component<SettingsButtonProps> {}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8,22 +8,22 @@ import {
 	ViewStyle
 } from 'react-native'
 
-interface SettingsDividerShortProps {
+export interface SettingsDividerShortProps {
 	ios?:boolean,
 	android?:boolean,
 	containerStyle?:ViewStyle,
 	dividerStyle?:ViewStyle,
 }
-type SettingsDividerShort = React.Component<SettingsDividerShortProps>;
+export declare class SettingsDividerShort extends React.Component<SettingsDividerShortProps> {}
 
-interface SettingsDividerLongProps {
+export interface SettingsDividerLongProps {
 	ios?:boolean,
 	android?:boolean,
 	dividerStyle?:ViewStyle,
 }
-type SettingsDividerLong = React.Component<SettingsDividerLongProps>;
+export declare class SettingsDividerLong extends React.Component<SettingsDividerLongProps> {}
 
-interface SettingsEditTextProps {
+export interface SettingsEditTextProps {
 	containerProps?: ViewProps,
 	containerStyle?: ViewStyle,
 	disabledOverlayStyle?: ViewStyle,
@@ -71,9 +71,9 @@ interface SettingsEditTextProps {
 	androidDialogOptions?: {any:any},
 	touchableProps?: TouchableOpacityProps
 }
-type SettingsEditText = React.Component<SettingsEditTextProps>;
+export declare class SettingsEditText extends React.Component<SettingsEditTextProps> {}
 
-interface SettingsPickerProps {
+export interface SettingsPickerProps {
 	containerProps?: ViewProps,
     containerStyle?: ViewStyle,
     disabledOverlayStyle?: ViewStyle,
@@ -83,7 +83,7 @@ interface SettingsPickerProps {
     valueProps?: TextProps,
     valueStyle?: TextStyle,
     value?: any,
-    valueFormat?: (input:T<any>)=>T,
+    valueFormat?: (input:any)=>any,
     valuePlaceholder?: string,
     options: Array<any>, //I honestly don't know how to type this
     dialogDescription?: string,
@@ -104,34 +104,34 @@ interface SettingsPickerProps {
       },
     },
     multi?: boolean,
-	renderCloseBtn?: JSX.Element,
+	renderCloseBtn?: React.Component,
 	// ↓↓↓ I'm not gonna read through the code that deeply to type every prop,
 	// ↓↓↓ especially since I won't use SettingsPicker at all in my app.
 	// ↓↓↓ If you want, type it correctly urself
-	renderListItem?: JSX.Element<{any:any}>, 
+	renderListItem?: React.Component, 
     singleRadio?: boolean,
 }
-type SettingsPicker = React.Component<SettingsPickerProps>;
+export declare class SettingsPicker extends React.Component<SettingsPickerProps> {}
 
-interface SettingCategoryHeaderProps {
+export interface SettingCategoryHeaderProps {
 	container?: ViewProps,
 	containerStyle?: ViewStyle,
 	titleProps?: TextProps,
 	titleStyle?: TextStyle,
 	title: string
 }
-type SettingsCategoryHeader = React.Component<SettingCategoryHeaderProps>;
+export declare class SettingsCategoryHeader extends React.Component<SettingCategoryHeaderProps> {}
 
-interface SettingsTextLabelProps {
+export interface SettingsTextLabelProps {
 	container?: ViewProps,
 	containerStyle?: ViewStyle,
 	titleProps?: TextProps,
 	titleStyle?: TextStyle,
 	title: string,  
 }
-type SettingsTextLabel = React.Component<SettingsTextLabelProps>;
+export declare class SettingsTextLabel extends React.Component<SettingsTextLabelProps> {}
 
-interface SettingsSwitchProps {
+export interface SettingsSwitchProps {
 	containerProps?: ViewProps,
     containerStyle?: ViewStyle,
     disabledOverlayStyle?: ViewStyle,
@@ -152,9 +152,10 @@ interface SettingsSwitchProps {
     },
     switchProps: object,
 }
-type SettingsSwitch = React.Component<SettingsSwitchProps>;
+export declare class SettingsSwitch extends React.Component<SettingsSwitchProps> {}
 
-interface SettingsButtonProps {
+
+export interface SettingsButtonProps {
 	containerProps?: TouchableOpacityProps,
     containerStyle?: ViewStyle,
     disabledOverlayStyle?: ViewStyle,
@@ -169,4 +170,4 @@ interface SettingsButtonProps {
     disabled?: boolean,
     onPress: (event: GestureResponderEvent) => void,
 }
-type SettingSwitch = React.Component<SettingsButtonProps>;
+export declare class SettingSwitch extends React.Component<SettingsButtonProps> {}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -123,3 +123,26 @@ interface SettingsTextLabelProps {
 	title: string,  
 }
 type SettingsTextLabel = React.Component<SettingsTextLabelProps>;
+
+interface SettingsSwitchProps {
+	containerProps?: ViewProps,
+    containerStyle?: ViewStyle,
+    disabledOverlayStyle?: ViewStyle,
+    titleProps?: TextProps,
+    titleStyle?: TextStyle,
+    title: string,
+    descriptionProps?: TextProps,
+    descriptionStyle?: TextStyle,
+    description?: string,
+    switchWrapperProps?: ViewProps,
+    switchWrapperStyle?: ViewStyle,
+    value: boolean,
+    disabled?: boolean,
+    onValueChange: (value: boolean) => void,
+    trackColor?: {
+      true: string,
+      false: string,
+    },
+    switchProps: object,
+}
+type SettingsSwitch = React.Component<SettingsSwitchProps>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -106,3 +106,11 @@ interface SettingsPickerProps {
 }
 type SettingsPicker = React.Component<SettingsPickerProps>;
 
+interface SettingCategoryHeaderProps {
+	container?: ViewProps,
+	containerStyle?: ViewStyle,
+	titleProps?: TextProps,
+	titleStyle?: TextStyle,
+	title: string
+}
+type SettingsCategoryHeader = React.Component<SettingCategoryHeaderProps>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import { ViewStyle } from 'react-native'
+
+interface SettingsDividerShortProps {
+	ios?:boolean,
+	android?:boolean,
+	containerStyle?:ViewStyle,
+	dividerStyle?:ViewStyle,
+}
+type SettingsDividerShort = React.Component<SettingsDividerShortProps>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -68,7 +68,7 @@ export interface SettingsEditTextProps {
 	androidDialogPlaceholder?:string,
 	// ↓↓↓ it's from react-native-dialogs package -> DialogAndroid.js -> "type OptionsPrompt" (on 183 line currently)
 	// ↓↓↓ I just don't know how to add it properly
-	androidDialogOptions?: {any:any},
+	androidDialogOptions?: {},
 	touchableProps?: TouchableOpacityProps
 }
 export declare class SettingsEditText extends React.Component<SettingsEditTextProps> {}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ViewStyle } from 'react-native'
+import { TextProps, TextStyle, TouchableOpacityProps, ViewProps, ViewStyle } from 'react-native'
 
 interface SettingsDividerShortProps {
 	ios?:boolean,
@@ -15,3 +15,53 @@ interface SettingsDividerLongProps {
 	dividerStyle?:ViewStyle,
 }
 type SettingsDividerLong = React.Component<SettingsDividerLongProps>;
+
+interface SettingsEditTextProps {
+	containerProps?: ViewProps,
+	containerStyle?: ViewStyle,
+	disabledOverlayStyle?: ViewStyle,
+	titleProps?: TextProps,
+	titleStyle?: TextStyle,
+	title: string,
+	valueProps?: TextProps,
+	valueStyle?: TextStyle,
+	value: string
+	valuePlaceholder?: string, 
+	valueFormat?: (input:string)=>string ,
+	negativeButtonTitle: string,
+	positiveButtonTitle: string,
+	dialogDescription?: string,
+	onValueChange: (text:string)=>void,
+	disabled?: boolean,
+	iosDialogInputType?:( 
+		'plain-text'|
+		'plain-text'|
+		'email-address'|
+		'numeric'|
+		'phone-pad'|
+		'ascii-capable'|
+		'numbers-and-punctuation'|
+		'url'|
+		'number-pad'|
+		'name-phone-pad'|
+		'decimal-pad'|
+		'twitter'|
+		'web-search'
+	),
+	androidDialogInputType?: (
+		null|
+		'numeric'|
+		'numbers-and-punctuation'|
+		'numeric-password'|
+		'email-address'|
+		'password'|
+		'phone-pad'|
+		'decimal-pad'
+	),
+	androidDialogPlaceholder?:string,
+	// ↓↓↓ it's from react-native-dialogs package -> DialogAndroid.js -> "type OptionsPrompt" (on 183 line currently)
+	// ↓↓↓ I just don't know how to add it properly
+	androidDialogOptions?: {any:any},
+	touchableProps?: TouchableOpacityProps
+}
+type SettingsEditText = React.Component<SettingsEditTextProps>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { TextProps, TextStyle, TouchableOpacityProps, View, ViewProps, ViewStyle } from 'react-native'
+import { GestureResponderEvent, TextProps, TextStyle, TouchableOpacityProps, View, ViewProps, ViewStyle } from 'react-native'
 
 interface SettingsDividerShortProps {
 	ios?:boolean,
@@ -146,3 +146,20 @@ interface SettingsSwitchProps {
     switchProps: object,
 }
 type SettingsSwitch = React.Component<SettingsSwitchProps>;
+
+interface SettingsButtonProps {
+	containerProps?: TouchableOpacityProps,
+    containerStyle?: ViewStyle,
+    disabledOverlayStyle?: ViewStyle,
+    titleProps?: TextProps,
+    titleStyle?: TextStyle,
+    title: string,
+    descriptionProps?: TextProps,
+    descriptionStyle?: TextStyle,
+    description?: string,
+    rightIconWrapperStyle?: ViewStyle,
+    rightIcon?: JSX.Element,
+    disabled?: boolean,
+    onPress: (event: GestureResponderEvent) => void,
+}
+type SettingSwitch = React.Component<SettingsButtonProps>;


### PR DESCRIPTION
### What is it?
I added .d.ts file with type declarations for all components (and their props) library exports. All types are based on `static props = {}` from each file but I changed props with `object` type to ViewProp, ViewStyle, TextProp etc. so everyone that uses this library will get more accurate intellisense hints.

#### notes

- SettingsEditText uses `androidDialogOptions` prop which then is passed to react-native-dialogs. This object is typed in DialogAndroid.js in `type OptionsPrompt` but since that project is written in JS and not TS(nor does it have a separate .d.ts file) I couldn't import it. So until react-native-dialogs doesn't fully switch to TS or creates a separate .d.ts file, let's leave it as it is.
- `renderListItem` in SettingsPicker.... look... I'm not gonna read through your code that deep just to type a 100% of the library. I'm not gonna use it in my app so I simply don't care enough. If you do, type it yourself, if not, I typed it simply as `React.Component` with no props.